### PR TITLE
Getopt_long returns a -1 when it's done parsing the command line.

### DIFF
--- a/96boardsctl/96boardsctl.c
+++ b/96boardsctl/96boardsctl.c
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
 	char *cmd[3], *serialnum = NULL;
 	int count = 0;
 	int rc;
-	char c;
+	signed char c;
 
 	progname = argv[0];
 

--- a/96boardsctl/README
+++ b/96boardsctl/README
@@ -3,31 +3,15 @@ Control utility for the 96board Console adapter
 This program will control the power button and reset button signals when using a
 96Boards USB console adaptor.
 
-This is a very simple utility, but unfortunately it isn't very convenient
-because it will disconnect the kernel driver from the UART adaptor when
-twiddling the pins, which means the console connection gets lost. The kernel
-driver needs to be reconnected by echoing the device address into the ftdi_sio
-driver's 'bind' file in sysfs.
-
 This program requires read/write access to the raw USB device in /dev/bus/usb/.
 For convenience, a udev rule can be used to make the device group writable when
 it is enumerated. Copy the file udev-rules/71-ftdi_sio.rules into
 /etc/udev/rules.d
 
-TODO:
-- Let CBUS pins be manipulated without disconnecting the kernel driver
-
-Prerequisites: cmake libftdi-0.20 and libusb-0.1
-
-There are much newer versions of libftdi and libusb, but v0.20 and v0.1
-are the versions packaged in Ubuntu. This program /should/ build against
-newer versions, but I've not been able to test it yet. (In fact, I'd
-really like to be using the latest libftdi because it adds proper FT230X
-eeprom support and would let me reconnect the kernel driver
-automatically, but that causes pain because v1.2 isn't packaged yet).
+Prerequisites: cmake libftdi1-2 and libusb-1.0
 
 Building:
-$ apt-get install libftdi-dev libusb-dev cmake
+$ apt-get install libftdi1-dev libusb-1.0-0-dev cmake
 $ cmake .
 $ make
 $ make install


### PR DESCRIPTION
Changed to a signed char so that this works when run on a raspberry pi.